### PR TITLE
Update README instructions for Auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,12 @@ The `spotifyremoji` package is a wrapper package for the Spotify API.
 * Alexander Kleefeldt / @akleefel
 * Charley Carriero / charcarr
 * Daniel Raff / @raffrica
-* Siobhan McCarter / @____
+* Siobhan McCarter / @siobhanmccarter
 
 
 ### Summary
-Description
+
+This is an R wrapper for the Spotify API. 
 
 
 ### Functions
@@ -30,6 +31,26 @@ It can be used as follows:
 ```
 DEMO!
 ```
+
+### Authentication 
+
+All of our functions require an authentication token. For more information on how to set up an authentication token please see [Spotify Docs](https://beta.developer.spotify.com/documentation/general/guides/authorization-guide/).   
+
+We have two easier options for users of this package to be able to provide the authentication tokens (the harder option is to read the [authorization guide](https://beta.developer.spotify.com/documentation/general/guides/authorization-guide/) and set it up). 
+
+Option 1: 
+> 1. Login to [Spotify for Developers](https://beta.developer.spotify.com/dashboard/) and Create an Client ID. 
+> 2. Click on `Web Console`, then pick an API call to explore. For instance click `Personalization` and then click on the `Get User's Top Artists and Tracks` end-point. Or can just click: [https://beta.developer.spotify.com/console/get-current-user-top-artists-and-tracks/](https://beta.developer.spotify.com/console/get-current-user-top-artists-and-tracks/). 
+> 3. Scroll down and click `GET TOKEN` under the OAuth Token Heading. Copy this string to your clipboard and use it with the above functions.  
+
+
+Option 2: 
+> 1. Login to [Spotify for Developers](https://beta.developer.spotify.com/dashboard/) and Create an Client ID. 
+> 2. Link to Jordan Roth's Repo: 
+> 3. Instructions for how to generate a local app.  
+
+Option 3: 
+> Develop your own Web App for Authorization following the Spotify Guides linked above.  
 
 ### Installation and examples:
 To install the package:


### PR DESCRIPTION
These instructions (namely option 1) will help with developing functions as it's how you'll get authorization tokens which all the Spotify API call require.   

I'll add the option from Jordan Roth's repo which will allow auth tokens in addition to just the developer's own token.  